### PR TITLE
Added option for no locations and improved output

### DIFF
--- a/Tests/CreateModel.py
+++ b/Tests/CreateModel.py
@@ -81,10 +81,10 @@ def supplyChainLocations():
     return all_locations
 
 model = Model.Model("Basic Crop")
-model.buildModel(supplyChainClasses, supplyChainLocations, returnCropRules, write_to_file = True, save_model_folder="Tests/ModelFiles/")
+model.buildModel(supplyChainClasses, returnCropRules, write_to_file = True, save_model_folder="Tests/ModelFiles/")
 
 model.initializeSolver(Solvers.GillespieSolver)
 start_date = datetime.datetime(2001, 8, 1)
 model.simulate(start_date, 100)
 
-model.trajectory.plotAllClassesOverTime(1)
+model.trajectory.plotAllClassesOverTime(0)

--- a/pyRBM/Build/Locations.py
+++ b/pyRBM/Build/Locations.py
@@ -1,5 +1,11 @@
 import numpy as np
 
+def returnDefaultLocation(defined_classes):
+    default_loc = Location(0, 0, "Default", "any")
+    default_loc.addClassLabels([class_tuple[0] for class_tuple in defined_classes])
+    return default_loc
+
+
 class Location:
     def __init__(self, lat:float, long:float, name:str, loc_type:str, constants = None, loc_prefix:str="loc_"):
         self.lat = lat
@@ -20,6 +26,9 @@ class Location:
         self.locations_variables = {}
 
         self.inital_conditions_dict = None
+    def addClassLabels(self, class_labels:list):
+        for class_label in class_labels:
+            self.class_labels.add(class_label)
 
     def addConstants(self, constants:list):
         if constants is not None:

--- a/pyRBM/Build/ProcessDescriptionFiles.py
+++ b/pyRBM/Build/ProcessDescriptionFiles.py
@@ -142,10 +142,7 @@ class CropRegions:
             if len(constants) == 0:
                 constants = extractColumns(region_row, exlude_list=["Name","Lat","Long"])
             
-            print(region_row["Lat"])
-            print(crop_stages.returnBasicStageDict())
             region = Utils.FarmRegion(crop_stages.returnBasicStageDict(), region_row["Lat"], region_row["Long"], region_row["Name"])
-            print(region_row.keys()[0])
             region.addAndSetConstants({constant.replace(" (Ha)","").replace(" ", "_"):float(region_row[constant]) for constant in constants})
             
             region.setInitialConditions({f"{crop}_Seeds":float(crop_stages.crop_info[crop]["Starting Seeds"]) for crop in crop_stages.crops})

--- a/pyRBM/Build/RuleMatching.py
+++ b/pyRBM/Build/RuleMatching.py
@@ -29,7 +29,7 @@ def returnRuleMatchingIndices(rules, locations):
                     matchedTypeToIndices[rule_targets_i].append(location_i)
         # From the previously described location set, obtain a tuple of indices (if it exists) that satisfies the rule.
         # Do this iteratively, loop over all index sets in construction and add the new index if it isn't already inside.
-        print(f"MATCHED {matchedTypeToIndices}")
+        #print(f"MATCHED {matchedTypeToIndices}")
         rule_indices = {}
         for rule_targets_i in range(len(rule["target_types"])):
             atleast_one_satisifying = False
@@ -87,7 +87,6 @@ def obtainPropensity(rule, locations, builtin_classes):
         # Add the built in class at the end of the location classes
 
         new_propensities.append(new_propensity)
-    print(new_propensities)
     return new_propensities
 
 def obtainStochiometry(rule, locations):

--- a/pyRBM/Build/RuleTemplates.py
+++ b/pyRBM/Build/RuleTemplates.py
@@ -11,7 +11,7 @@ class SingleLocationRule(Rules.Rule):
               self.addSimplePropensityFunction([0], [propensity], [propensity_classes])
 
 class SingleLocationProductionRule(SingleLocationRule):
-       def __init__(self, target, reactant_classes, reactant_amount, 
+       def __init__(self, target, reactant_classes, reactant_amount,
                     product_classes, product_amount,
                     propensity, propensity_classes, 
                     rule_name="SINGLE LOCATION PRODUCTION RULE"):

--- a/pyRBM/Core/Cache.py
+++ b/pyRBM/Core/Cache.py
@@ -5,18 +5,20 @@ import numpy as np
 import pyRBM.Simulation.Rule as Rule
 import pyRBM.Simulation.Location as Location
 
-def writeDictToJSON(dict_to_write:dict, filename:str):
+def writeDictToJSON(dict_to_write:dict, filename:str, dict_name:str=""):
     
     folder =''.join([folder+'/' for folder in filename.split("/")[:-1]])
     dir_to_create = os.path.join(os.curdir,folder)
 
-    print(dir_to_create)
     if not os.path.exists(dir_to_create):
-        print("no")
+        print(f"Creating folder: {dir_to_create}")
         os.makedirs(dir_to_create)
 
     json_file = json.dumps(dict_to_write, indent=4, sort_keys=True)
     with open(f"{filename}.json", "w+", encoding='utf-8') as outfile:
+            if dict_name != "":
+                dict_name += " "
+            print(f"Writing {dict_name}to file: {filename}.json")
             outfile.write(json_file)
 
 def readDictFromJSON(filename:str):

--- a/pyRBM/Simulation/Solvers.py
+++ b/pyRBM/Simulation/Solvers.py
@@ -55,8 +55,6 @@ class Solver:
                 rule_prop_update_set = rule_prop_update_set.copy()
                 for changed_model_var in changed_base_model_vars:
                     rule_prop_update_set.update(self.propensity_update_dict.get(changed_model_var, set()))
-                    if changed_model_var == "model_month_jan":
-                        print(self.propensity_update_dict.get(changed_model_var, set()))
             self.updateGivenPropensities(rule_prop_update_set)
         else:
             self.updateGivenPropensities()

--- a/pyRBM/Simulation/State.py
+++ b/pyRBM/Simulation/State.py
@@ -17,7 +17,6 @@ class ModelState:
         for model_class in model_classes:
             if model_class in self.IMPLEMENTED_MODEL_CLASSES:
                 self.model_classes[model_class] = None
-                print(f"{model_class} implemented")
             else:
                 self.model_classes[model_class] = None
                 raise(ValueError(f"Model class {model_class} not implemented"))

--- a/pyRBM/Simulation/StaticSeries.py
+++ b/pyRBM/Simulation/StaticSeries.py
@@ -1,0 +1,14 @@
+import pandas as pd
+class TimeSeries:
+
+    def __init__(self, source_filepath:str):
+        self.file_ending = source_filepath.split('.')[-1]
+
+        if self.file_ending == "csv":
+            time_series_data = pd.read_csv(source_filepath, converters={})
+            print(time_series_data)
+
+        else:
+            raise(ValueError(f"File ending {self.file_ending} is currently an unsupported time series."))
+    
+TimeSeries("Backend/ModelSimulation/testfiles/ts.csv")


### PR DESCRIPTION
Passing None into model loading (locations_filename) or model building (create_locations_func) creates a dummy location. 

The rule targets are changed to allow for this but warns when any of the rule targets are not None or "any".

Currently to set initial conditions a location object is required but the ability to set initial conditions directly will be added.

Additionally, removed debugging print statements and added some meaningful print statements for the model building.

Resolves #5 