### PR TITLE
Added slot based addressing - final part to proper spatial modelling

### DIFF
--- a/Tests/SIR_Example.py
+++ b/Tests/SIR_Example.py
@@ -1,0 +1,56 @@
+import datetime
+
+import pyRBM.Core.Model as Model
+import pyRBM.Build.Compartment as Compartments
+import pyRBM.Build.RuleTemplates as BasicRules
+import pyRBM.Simulation.Solvers as Solvers
+
+
+epiClasses = [["S", "people"], ["I", "people"], ["R", "people"]]
+
+class EpiCompartment(Compartments.Compartment):
+    def __init__(self, name:str, constants = None):
+        # Sets lat/long and creates and empty set of compartment labels.
+        if constants is None:
+            constants = ["infectivity_rate", "recovery_rate", "mortality_rate"]
+        super().__init__(name, comp_type="EpiComp", constants=constants)
+        # Crops exist in three stages in this simplified model: planted, growing and harvested.
+        class_labels = [class_entry[0] for class_entry in epiClasses]
+        self.addClassLabels(class_labels)
+
+
+def epiRules():
+    infection = BasicRules.SingleLocationProductionRule("EpiComp",
+                                                        "S", 1,
+                                                        "I", 1,
+                                                       "S*I*comp_infectivity_rate", ["I","S"],
+                                                       "Infection of Susceptible")
+    recovery = BasicRules.SingleLocationProductionRule("EpiComp",
+                                                       "I", 1,
+                                                       "R", 1,
+                                                       "I*comp_recovery_rate", "I", 
+                                                       "Recovery of Infected")
+    death = BasicRules.ExitEntranceRule("EpiComp",
+                                        "I", 1,
+                                        "I*comp_mortality_rate", "I",
+                                        "Death of Infected")
+    return  [infection, recovery, death]
+
+def epiLocations():
+    single_epi_comp = EpiCompartment("Example_Name", constants={"infectivity_rate" : 0.1,
+                                                                "recovery_rate" : 0.2,
+                                                                "mortality_rate" : 0.3 })
+    return [single_epi_comp]
+
+model = Model.Model("Basic Epi Model")
+model.buildModel(epiClasses, epiRules, epiLocations, write_to_file = True, save_model_folder="Tests/ModelFiles/")
+model_solver = Solvers.GillespieSolver(debug=True)
+model.initializeSolver(model_solver)
+
+start_date = datetime.datetime(2001, 8, 1)
+
+model.simulate(start_date, 10000, 10000)
+
+
+model.printSimulationPerformanceStats()
+model.trajectory.plotAllClassesOverTime(0)

--- a/pyRBM/Build/Classes.py
+++ b/pyRBM/Build/Classes.py
@@ -9,6 +9,7 @@ class Classes:
     
     def addClass(self, class_name:str, class_measurement_unit:str,
                  class_restriction:str = "None") -> None:
+        class_name = class_name.replace(" ", "_").lower()
         if class_name in self.base_model_string:
             raise(ValueError(f"Class: {class_name} cannot contain model prefix{self.base_model_string}"))
         elif not class_name in self.class_names:

--- a/pyRBM/Build/RuleMatching.py
+++ b/pyRBM/Build/RuleMatching.py
@@ -49,29 +49,30 @@ def returnRuleMatchingIndices(rules:dict[str,dict[str,Any]],
                 # We keep a dictionary here so we can map explict types.
                 correct_length_rules = {}
                 for comp_index in matched_type_to_indices[rule_targets_i]:
+                    comp_key = str(comp_index)
                     # Which explict types are being used.
                     for rule_key, index_matches in rule_indices.items():
                         for index_matching in index_matches:
                             if comp_index not in index_matching:
-                                if rule_key+"_"+compartments[comp_index]["type"] not in correct_length_rules:
-                                    correct_length_rules[rule_key+"_"+compartments[comp_index]["type"]] = [index_matching+[comp_index]]
+                                if rule_key+"_"+compartments[comp_key]["type"] not in correct_length_rules:
+                                    correct_length_rules[rule_key+"_"+compartments[comp_key]["type"]] = [index_matching+[comp_index]]
                                 else:
-                                    correct_length_rules[rule_key+"_"+compartments[comp_index]["type"]].append(index_matching+[comp_index])
+                                    correct_length_rules[rule_key+"_"+compartments[comp_key]["type"]].append(index_matching+[comp_index])
                                 atleast_one_satisifying = True
                 rule_indices = correct_length_rules
 
             # Prune rules that will never able to be completed to reduce size.
-            #correct_length_rules = [] 
+            #correct_length_rules = []
             #for rule_index in rule_indices:
                 #if len(rule_index) == rule_targets_i+1:
                     #correct_length_rules.append(rule_index)
 
             if not atleast_one_satisifying:
-                raise(ValueError(f"Rule {rule_i} has no satisying compartment for required type index{rule_targets_i}, type {str(rule['target_types'][rule_targets_i])}. Rule will never be trigger - remove rule"))
+                raise ValueError(f"Rule {rule_i} has no satisying compartment for required type index{rule_targets_i}, type {str(rule['target_types'][rule_targets_i])}. Rule will never be trigger - remove rule")
         filled_rules[str(rule_i)] = rule_indices
     return filled_rules
 
-# Return the final propensity for a given rule provided concrete compartments. 
+# Return the final propensity for a given rule provided concrete compartments.
 # Assumption that compartments of the same type have the same compartments.
 def obtainPropensity(rule:dict[str,Any], compartments:list[dict[str,Any]], builtin_classes:list[list[str]]) -> list[str]:
     propensities = rule["propensities"]
@@ -82,10 +83,10 @@ def obtainPropensity(rule:dict[str,Any], compartments:list[dict[str,Any]], built
         # Order: model var, compartment const, compartment class
         for built_in_i, builtin_class in enumerate(builtin_classes):
             new_propensity = new_propensity.replace(builtin_class[0], f"x{built_in_i+len(new_label_mapping)}")
-            
 
         for label_i in new_label_mapping:
             new_propensity = new_propensity.replace(new_label_mapping[label_i], f"x{label_i}")
+
         # Add the built in class at the end of the compartment classes
 
         new_propensities.append(new_propensity)
@@ -127,9 +128,9 @@ def obtainStochiometry(rule:dict[str,Any], compartments:list[dict[str,Any]]) -> 
                     # Only needs to happen once so can be placed here, possibly refactor
                     class_found = True
             if not class_found:
-                raise(ValueError("Rule class not found in compartment class in rule matching (missing stoichiometry class)."))
+                raise ValueError("Rule class not found in compartment class in rule matching (missing stoichiometry class).")
         new_stoichiometries.append(list(new_stoichiometry))
-        
+
     return new_stoichiometries
 
 def returnMatchedRulesDict(rules:dict[str,dict[str,Any]], compartments:dict[str,dict[str,Any]],
@@ -150,7 +151,7 @@ def returnMatchedRulesDict(rules:dict[str,dict[str,Any]], compartments:dict[str,
             # Take the first set as an example
             for compartment_index in matched_rule[concrete_rule_type][0]:
                 example_compartments.append(compartments[str(compartment_index)])
-            
+
             # TODO ensure compatibility with further propensity functions
             concrete_rule_dict["stoichiomety"] = obtainStochiometry(rule, example_compartments)
             concrete_rule_dict["propensity"] = obtainPropensity(rule, example_compartments,

--- a/pyRBM/Build/RuleTemplates.py
+++ b/pyRBM/Build/RuleTemplates.py
@@ -28,7 +28,7 @@ class SingleLocationProductionRule(SingleLocationRule):
                     product_classes:list[str], product_amount:Sequence[Union[float, int]],
                     propensity:str, propensity_classes:list[str],
                     rule_name:str ="SINGLE LOCATION PRODUCTION RULE") -> None:
-            
+
             reactants_len = len(reactant_classes)
             product_len = len(product_classes)
             stoichiometry = np.zeros(reactants_len+product_len)
@@ -59,10 +59,10 @@ class TransportRule(Rule):
                 the second element is a list of the classes required by the target propensity term.
             rule_name (str, optional):
           """
-          super().__init__(rule_name, [source, target])
+          assert len(propensities) == 2
+          assert len(propensity_classes) == 2
 
-          assert(len(propensities) == 2)
-          assert(len(propensity_classes) == 2)
+          super().__init__(rule_name, [source, target])
 
           source_stochiometry = np.array([-transport_amount])
           target_stochiometry = np.array([transport_amount])

--- a/pyRBM/Build/RuleTemplates.py
+++ b/pyRBM/Build/RuleTemplates.py
@@ -12,11 +12,16 @@ class SingleLocationRule(Rule):
     """ A template for a rule at a single compartment.
     """
     def __init__(self, target:str, propensity:str, stoichiomety,
-                  propensity_classes:list[str], stoichiometry_classes:list[str],
+                  propensity_classes:Union[list[str], str], stoichiometry_classes:Union[str, list[str]],
                   rule_name:str = "SINGLE LOCATION RULE") -> None:
             """ A template for a rule at a single compartment. TODO
             """
             super().__init__(rule_name, [target])
+            if isinstance(propensity_classes, str):
+                 propensity_classes = [propensity_classes]
+            if isinstance(stoichiometry_classes, str):
+                 stoichiometry_classes = [stoichiometry_classes]
+      
             self.addLinearStoichiomety([0], [stoichiomety],
                                         [stoichiometry_classes])
             self.addSimplePropensityFunction([0], [propensity],
@@ -24,11 +29,24 @@ class SingleLocationRule(Rule):
 
 class SingleLocationProductionRule(SingleLocationRule):
        def __init__(self, target:str,
-                    reactant_classes:list[str], reactant_amount:Sequence[Union[float, int]],
-                    product_classes:list[str], product_amount:Sequence[Union[float, int]],
-                    propensity:str, propensity_classes:list[str],
+                    reactant_classes:Union[list[str], str], reactant_amount:list[Union[float, int]],
+                    product_classes:Union[list[str], str], product_amount:list[Union[float, int]],
+                    propensity:str, propensity_classes:Union[list[str], str],
                     rule_name:str ="SINGLE LOCATION PRODUCTION RULE") -> None:
+            if isinstance(reactant_classes, str):
+                 assert isinstance(reactant_amount, (float,int))
+                 reactant_classes = [reactant_classes]
+                 reactant_amount = [reactant_amount]
+            else:
+                 assert isinstance(reactant_amount, list)
 
+            if isinstance(product_classes, str):
+                 assert isinstance(product_amount, (float,int))
+                 product_classes = [product_classes]
+                 product_amount = [product_amount]
+            else:
+                 assert isinstance(product_amount, list)
+           
             reactants_len = len(reactant_classes)
             product_len = len(product_classes)
             stoichiometry = np.zeros(reactants_len+product_len)
@@ -77,7 +95,7 @@ class ExitEntranceRule(Rule):
   """
   def __init__(self, target:str, transport_class:str,
                 transport_amount:Union[float, int], propensity:str,
-                propensity_classes:list[str],
+                propensity_classes:Union[list[str], str],
                 rule_name:str = "EXIT/ENTRANCE RULE") -> None:
         """ A template for a transport rule for a single class between a single source compartment and a single target compartment.
         Args:
@@ -89,6 +107,7 @@ class ExitEntranceRule(Rule):
             rule_name (str, optional):
         """
         super().__init__(rule_name, [target])
-
+        if isinstance(propensity_classes, str):
+             propensity_classes = [propensity_classes]
         self.addLinearStoichiomety([0], [[transport_amount]], [[transport_class]])
         self.addSimplePropensityFunction([0], [propensity], [propensity_classes])

--- a/pyRBM/Build/Rules.py
+++ b/pyRBM/Build/Rules.py
@@ -85,7 +85,7 @@ class Rule:
         res = sympy_formula.evalf(subs=subsitution_dict)
         # We require that a numerical result is outputted and no symbols are left over.
         if not isinstance(res, (sympy.core.numbers.Float, sympy.core.numbers.Zero)):
-            raise ValueError(f"Propensity function: {formula} evaluates to {res} and not a number. \nPlease check Compartment constants/classes and model classes are defined.")
+            raise ValueError(f"Propensity function: {formula} evaluates to {res} and not a number. \nPlease check Compartment constants/classes and model classes are defined. \nSymbols available for: {class_symbols}")
         return True
 
     def checkRuleDefinition(self, builtin_class_symbols:dict[str, sympy.Symbol],

--- a/pyRBM/Core/Cache.py
+++ b/pyRBM/Core/Cache.py
@@ -140,8 +140,7 @@ def loadCompartments(compartments_filename:Optional[str] = None,
 
     for comp_index in range(len(compartments_data)):
         compartment_dict = compartments_data[str(comp_index)]
-        compartment = Compartment(index=comp_index, name=compartment_dict["compartment_name"], lat=float(compartment_dict["lat"]),
-                                     long=float(compartment_dict["long"]), comp_type=compartment_dict["type"],
+        compartment = Compartment(index=comp_index, name=compartment_dict["compartment_name"], comp_type=compartment_dict["type"],
                                      label_mapping=compartment_dict["label_mapping"],
                                      initial_class_values=np.array(compartment_dict["initial_values"]),
                                      compartment_constants=compartment_dict["compartment_constants"])

--- a/pyRBM/Core/Cache.py
+++ b/pyRBM/Core/Cache.py
@@ -147,7 +147,7 @@ def loadCompartments(compartments_filename:Optional[str] = None,
                                      compartment_constants=compartment_dict["compartment_constants"])
         compartment_list.append(compartment)
     return compartment_list
-    
+
 
 def loadMatchedRules(compartments,  num_builtin_classes:int, matched_rules_filename:Optional[str] = None,
                      matched_rule_dict:Optional[dict]=None) -> tuple[list[Rule], list[list[int]]]:
@@ -164,7 +164,7 @@ def loadMatchedRules(compartments,  num_builtin_classes:int, matched_rules_filen
     rules_list = []
     applicable_indices = []
     rules_data =  processFilenameOrDict(matched_rules_filename, matched_rule_dict)
-    
+
     for rule_index in range(len(rules_data)):
         rules_dict = rules_data[str(rule_index)]
         stochiometries = []
@@ -179,7 +179,7 @@ def loadMatchedRules(compartments,  num_builtin_classes:int, matched_rules_filen
         rule = Rule(propensity=propensities, stoichiometry=stochiometries, rule_name=rules_dict["rule_name"],
                          num_builtin_classes=num_builtin_classes, compartments=compartments,
                          rule_index_sets=rules_dict["matching_indices"])
-        
+
         applicable_indices.append(rules_dict["matching_indices"])
         rules_list.append(rule)
     return (rules_list, applicable_indices)

--- a/pyRBM/Core/Model.py
+++ b/pyRBM/Core/Model.py
@@ -44,7 +44,7 @@ class Model:
         self.defined_classes:Optional[list[str]] = None
 
         self.model_paths = ModelPaths()
-        
+
     def createCompartments(self) -> dict[str, dict[str, Any]]:
         """ Parse all compartments returned from the `self._create_rules_func`, perform rule validity and cohesion checks and return them in dictionary format.
         """
@@ -99,8 +99,8 @@ class Model:
         if self.contains_builtin_classes:
             additional_classes = Classes().returnBuiltInClasses()
         return returnMatchedRulesDict(self._rules_dict, self._compartments_dict, additional_classes)
-    
-    
+
+
     def buildModel(self, classes_defintions:Iterable[Iterable[str]],
                    create_rules:Callable[[], Iterable[Rule]],
                    create_compartments:Optional[Callable[[], Iterable[Compartment]]] = None,
@@ -111,8 +111,8 @@ class Model:
                    matched_rules_filename:str = "CompartmentMatchedRules",
                    classes_filename:str = "Classes",
                    metarule_filename:str = "MetaRules") -> None:
-        
-        
+
+
         self.classes_defintions = classes_defintions
         self._create_compartments_func = create_compartments
         self._create_rules_func = create_rules
@@ -128,17 +128,17 @@ class Model:
 
         if self.write_to_file:
             self.model_paths = ModelPaths(metarules_filename=metarule_filename if save_meta_rules else None,
-                                          compartments_filename=compartment_filename if self.no_compartment_model else None,
+                                          compartments_filename=compartment_filename if not self.no_compartment_model else None,
                                           matched_rules_filename=matched_rules_filename,
                                           classes_filename=classes_filename,
                                           model_folder_path_to=save_model_folder,
                                           model_name=self.model_name)
-            
+
             files_to_write = [(self._matched_rules_dict,self.model_paths.matched_rules_path, "matched rules dict"),
                               (self._classes_dict, self.model_paths.classes_path, "classes dict")]
             if self.model_paths.metarules_path is not None:
                 files_to_write.append((self._rules_dict, self.model_paths.metarules_path, "meta rule dict"))
-            
+
             if self.model_paths.compartments_path is not None:
                 files_to_write.append((self._compartments_dict, self.model_paths.compartments_path, "compartments dict"))
 
@@ -147,7 +147,7 @@ class Model:
                 self.classes_filename,self.metarule_filename = [save_model_folder,compartment_filename,
                                                                 matched_rules_filename,classes_filename,
                                                                 metarule_filename]
-            
+
             for model_dict, file_loc, dict_name in files_to_write:
                 writeDictToJSON(model_dict, file_loc, dict_name)
         else:
@@ -213,7 +213,7 @@ class Model:
 
         self.trajectory = Trajectory(self.compartments)
         self.model_state = ModelState(self.builtin_classes, datetime.datetime.now())
-        
+
         self.solver = None
         self.solver_initialized = False
         self.model_initialized = True
@@ -254,7 +254,7 @@ class Model:
                                                            "total_propensity"])
                 self.model_debug_plot = SolverDataPlotting(self)
         else:
-            raise(ValueError("Model not initialized: initialize model before solver"))
+            raise ValueError("Model not initialized: initialize model before solver")
 
     def resetSimulation(self) -> None:
         """ Resets the model to a pre-simulation state and creates a new Trajectory.
@@ -318,7 +318,7 @@ class Model:
                     self.solver_diag_data.updateData(self.solver.current_stats)
             end_perf_time = time.perf_counter()
             time_elapsed = end_perf_time-start_perf_time
-            
+
             print(f"Simulation {self.simulation_number} has finished after {self.model_state.elapsed_time} {self.model_state.time_measurement}, requiring {self.model_state.iterations} iterations and {time_elapsed} secs of compute time")
 
             self.simulation_elapsed_times.append(time_elapsed)
@@ -327,7 +327,7 @@ class Model:
                 self.solver_diag_data.saveSolverPerSimulationData()
             return self.trajectory
         else:
-            raise(ValueError("Model/solver not initialized: initialize model before the solver."))
+            raise ValueError("Model/solver not initialized: initialize model before the solver.")
 
     def printSimulationPerformanceStats(self) -> None:
         """ Prints (computational) performance statistics for the current model (since its inception).

--- a/pyRBM/Core/Plotting.py
+++ b/pyRBM/Core/Plotting.py
@@ -10,11 +10,11 @@ class SolverDataPlotting:
         assert(model.solver.debug)
         self.fig, self.ax = plt.subplots(2,2)
 
-        self.rule_names = [str(rule)for rule in model.matched_rules_dict]
+        self.rule_names = [str(rule)for rule in model._matched_rules_dict]
       
         self.rule_index_set_names = [f"{rule}_{index}"
                                      for rule in self.rule_names 
-                                     for index in range(len(model.matched_rules_dict[rule]))]
+                                     for index in range(len(model._matched_rules_dict[rule]))]
 
         self.rule_plot = FrequencyBarChart(self.fig, self.ax[0][0],
                                            "Frequency of rule execution", "Rule Number",

--- a/pyRBM/Simulation/Compartment.py
+++ b/pyRBM/Simulation/Compartment.py
@@ -11,9 +11,9 @@ class Compartment:
         self.initial_class_values = initial_class_values
         self.class_values = initial_class_values
         self.compartment_constants = compartment_constants
-    
+
     def updateCompartmentValues(self, new_values) -> None:
         self.class_values = new_values
-    
+
     def reset(self) -> None:
         self.class_values = self.initial_class_values

--- a/pyRBM/Simulation/Compartment.py
+++ b/pyRBM/Simulation/Compartment.py
@@ -1,10 +1,8 @@
 class Compartment:
-    def __init__ (self, index, name:str, lat, long, comp_type, label_mapping,
+    def __init__ (self, index, name:str, comp_type, label_mapping,
                   initial_class_values, compartment_constants) -> None:
         self.index = index
         self.name = name
-        self.lat = lat
-        self.long = long
         self.comp_type = comp_type
         self.label_mapping = label_mapping
 

--- a/pyRBM/Simulation/Rule.py
+++ b/pyRBM/Simulation/Rule.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import sympy
 
@@ -7,48 +9,81 @@ class Rule:
     def __init__(self, propensity:list[str],
                  stoichiometry:list[np.ndarray],
                  rule_name:str, num_builtin_classes:int,
-                 compartments:dict[int, Compartment],
+                 compartments:list[Compartment],
                  rule_index_sets:list[list[int]]) -> None:
 
-        assert (len(stoichiometry) == len(propensity))
+        assert len(stoichiometry) == len(propensity)
+        compartment_names = [compartment.name for compartment in compartments]
         if isinstance(propensity, (list)):
             self.lambda_propensities = []
             self.contains_compartment_constant = []
+            self.contains_slot_match_constant = []
             self.sympy_formula = []
+            comp_prop_dict = None
 
             for slot_i, formula_str in enumerate(propensity):
-                symbol_string = ''.join([f'x{str(i)} '
+                symbol_string = ''.join([f"x{str(i)} "
                                          for i in range(len(stoichiometry[slot_i])+num_builtin_classes)])
                 formula_symbols = sympy.symbols(symbol_string, real=True)
-                if "comp_" not in formula_str:
+                # We only need one propensity function for this rule.
+                if "comp_" not in formula_str and "slot_" not in formula_str:
                     formula = sympy.parse_expr(formula_str)
                     self.sympy_formula.append(formula)
-                    f=sympy.lambdify(formula_symbols, formula.simplify(), "numpy")
+                    comp_prop_dict=sympy.lambdify(formula_symbols, formula.simplify(), "numpy")
                     self.contains_compartment_constant.append(False)
-                else:
+                    self.contains_slot_match_constant.append(False)
+                # We need multiple propensity functions for this rule as we have compartment specific information.
+                elif "slot_" not in formula_str:
                     applicable_indices = self._findIndices(rule_index_sets, slot_i)
                     #formula_without_constants = self.subsituteConstants(formula_str, {key:"" for key in list(compartments[applicable_indices[0]].compartment_constants.keys())})
+                    comp_prop_dict = {comp_index: sympy.lambdify(formula_symbols,
+                                        sympy.parse_expr(self._subsituteConstants(formula_str, compartments[comp_index].compartment_constants,
+                                                                                  None)).simplify(),
+                                                        "numpy")
+                                        for comp_index in applicable_indices}
 
-                    f = {comp_index: sympy.lambdify(formula_symbols,
-                                                   sympy.parse_expr(self._subsituteConstants(formula_str, compartments[comp_index].compartment_constants)).simplify(),
-                                                   "numpy")
-                        for comp_index in applicable_indices}
-
+                    # self.sympy_formula is used for precomputing rules only and uses an example set of locations - should not be used
+                    # generally.
                     self.sympy_formula.append(sympy.parse_expr(self._subsituteConstants(formula_str,
-                                                compartments[applicable_indices[0]].compartment_constants)))
+                                                compartments[applicable_indices[0]].compartment_constants,
+                                                None)))
 
                     self.contains_compartment_constant.append(True)
+                    self.contains_slot_match_constant.append(False)
 
-                self.lambda_propensities.append(f)
+                else:
+                    #formula_without_constants = self.subsituteConstants(formula_str, {key:"" for key in list(compartments[applicable_indices[0]].compartment_constants.keys())})
+                    comp_prop_dict = {comp_index: sympy.lambdify(formula_symbols,
+                                        sympy.parse_expr(self._subsituteConstants(formula_str, compartments[index_set[slot_i]].compartment_constants,
+                                                                                  np.take(compartment_names, rule_index_sets[comp_index]))).simplify(),
+                                                        "numpy")
+                                        for comp_index, index_set in enumerate(rule_index_sets)}
+
+                    # self.sympy_formula is used for precomputing rules only and uses an example set of locations - should not be used
+                    # generally.
+                    self.sympy_formula.append(sympy.parse_expr(self._subsituteConstants(formula_str,
+                                                compartments[rule_index_sets[0][slot_i]].compartment_constants,
+                                                np.take(compartment_names, rule_index_sets[0]))))
+
+                    self.contains_compartment_constant.append(True)
+                    self.contains_slot_match_constant.append(True)
+
+                self.lambda_propensities.append(comp_prop_dict)
             # To remove
             #self.propensity_function = lambda x, comp : np.dot(x, self.propensity_matrix[comp])
         else:
-            raise(ValueError("Unsupported Propensity in Model Loading"))
+            raise ValueError("Unsupported Propensity in Model Loading")
         self.rule_name = rule_name
         self.stoichiometry = stoichiometry
         self.contains_compartment_constant = np.array(self.contains_compartment_constant)
-    
-    def _subsituteConstants(self, formula_str:str, compartment_constants:dict) -> str:
+        self.contains_slot_match_constant = np.array(self.contains_slot_match_constant)
+
+    def _subsituteConstants(self, formula_str:str, compartment_constants:dict, compartments_names:list) -> str:
+        # The slot to name substitution is performed prior to constant to value substitution,
+        # to allow for constant with slot_ to be formed.
+        for slots_i, compartment_name in enumerate(compartments_names):
+            formula_str = formula_str.replace(f"slot_{slots_i}", compartment_name)
+        
         out_formula = formula_str
         for comp_constant in compartment_constants:
             out_formula = out_formula.replace(comp_constant,
@@ -62,14 +97,14 @@ class Rule:
             possible_indices.add(index_set[slot_index])
 
         return list(possible_indices)
-    
+
     def _compartmentAttemptedCompartmentChange(self, class_values, compartment_index:int,
                                             times_triggered:int):
         new_values = class_values + times_triggered*self.stoichiometry[compartment_index]
 
         return new_values
-    
-    def returnPropensity(self, compartments, builtin_classes):
+
+    def returnPropensity(self, compartments, builtin_classes, index_set_i):
         assert(len(compartments) == len(self.stoichiometry))
         # Assume product operation.
         propensity = 1
@@ -79,18 +114,23 @@ class Rule:
             if not self.contains_compartment_constant[comp_i]:
                 propensity *= max(0, self.lambda_propensities[comp_i](*compartment.class_values,
                                                                      *builtin_classes))
-            else:
+            elif not self.contains_slot_match_constant[comp_i]:
                 propensity *= max(0, self.lambda_propensities[comp_i][compartment.index](*compartment.class_values,
                                                                                      *builtin_classes))
+            else:
+                propensity *= max(0, self.lambda_propensities[comp_i][index_set_i](*compartment.class_values,
+                                                                                     *builtin_classes))
+                #print(self.lambda_propensities[comp_i][index_set_i](*compartment.class_values,
+                 #                                                                    *builtin_classes))
 
-        assert (propensity >= 0)
+        assert propensity >= 0
         return propensity
-    
+
     # We expect pure Gillespie to have 0 propensity for negative rule changes, however with Tau leaping we may need
     # to check whether a series of rule changes leads to negative values.
     def triggerAttemptedRuleChange(self, compartments,
                                    times_triggered:int = 1) -> bool:
-        assert(len(compartments) == len(self.stoichiometry))
+        assert len(compartments) == len(self.stoichiometry)
         negative_vals = False
         new_class_values = []
 

--- a/pyRBM/Simulation/State.py
+++ b/pyRBM/Simulation/State.py
@@ -23,7 +23,7 @@ class ModelState:
                 self.model_classes[model_class] = None
             else:
                 self.model_classes[model_class] = None
-                raise(ValueError(f"Model class {model_class} not implemented"))
+                raise ValueError(f"Model class {model_class} not implemented")
 
 
         self.elapsed_time = 0
@@ -37,9 +37,9 @@ class ModelState:
             self.start_datetime = start_datetime
             self.current_datetime = start_datetime
         else:
-            raise(ValueError(f"Start date must be of type datetime not {type(start_datetime)}"))
+            raise ValueError(f"Start date must be of type datetime not {type(start_datetime)}")
         self._initaliseCalendarInfo()
-        
+
     def reset(self) -> None:
         self.elapsed_time = 0
         self.iterations = 0
@@ -53,8 +53,8 @@ class ModelState:
         for key in self.IMPLEMENTED_MODEL_CLASSES:
             self.model_classes[key] = 0
         self._updateCalendarInfo()
-    
-    
+
+
     def changeDate(self, new_date:datetime) -> None:
         self.start_datetime = new_date
         self.reset()
@@ -86,7 +86,7 @@ class ModelState:
         if not self.model_classes[f"{self.model_prefix}day"] == current_datetime_info[2]:
             self.model_classes[f"{self.model_prefix}day"] = current_datetime_info[2]
             self.changed_vars.append(f"{self.model_prefix}day")
-        
+
         rounded_hours = round(current_datetime_info[4]/60.0, 1)
         if not self.model_classes[f"{self.model_prefix}hour"] == current_datetime_info[3] + rounded_hours:
             self.model_classes[f"{self.model_prefix}hour"] = current_datetime_info[3] + rounded_hours
@@ -95,7 +95,7 @@ class ModelState:
 
     def processUpdate(self, new_time) -> None:
         self.changed_vars = []
-        if new_time == None:
+        if new_time is None:
             print("Ending model simulation")
             return
         self._updateTime(new_time)
@@ -109,18 +109,18 @@ class ModelState:
         elif self.time_measurement == "days":
             time_change = timedelta(days=time_diff)
         else:
-            raise(ValueError(f"Unsupported time increment type {self.time_measurement}"))
-        
+            raise ValueError(f"Unsupported time increment type {self.time_measurement}")
+
         self.current_datetime = self.current_datetime + time_change
         self.elapsed_time = new_time
 
         self._updateCalendarInfo()
-        
+
     def returnModelClassesValues(self) :
         return self.model_classes.values()
-    
+
     def returnModelClasses(self):
         return list(self.model_classes.values())
-                    
+
     def returnChangedVars(self) -> list[str]:
         return self.changed_vars

--- a/pyRBM/Simulation/Trajectory.py
+++ b/pyRBM/Simulation/Trajectory.py
@@ -16,6 +16,8 @@ class Trajectory:
                                 for compartment_index, compartment in enumerate(compartments)}
         self.compartment_names = {compartment_index:compartment.name
                                for compartment_index, compartment in enumerate(compartments)}
+        
+        #self.time_resolution = 
 
     def addEntry(self, time, compartment_values,
                  compartment_index:int) -> None:


### PR DESCRIPTION
Use slot_#SLOT NUMBER HERE# to access the name of the compartment that was matched at the slot number.

Note the slot number uses zero-indexing.

### Example:
For a two slot rule e.g. a transport rule of compartment type A to compartment type B might depend on distance.

Propensity: ["transport_class*comp_distance_slot_1", "1"]
Targets ["A", "B"]