### PR TITLE
Fixed model variables propensity cache issue

### DIFF
--- a/Tests/Seasonal_Example.py
+++ b/Tests/Seasonal_Example.py
@@ -1,0 +1,48 @@
+import datetime
+
+import pyRBM.Core.Model as Model
+import pyRBM.Build.Compartment as Compartments
+import pyRBM.Build.RuleTemplates as BasicRules
+import pyRBM.Simulation.Solvers as Solvers
+
+
+model_classes = [["Source_Var", "units"],
+              ["Target_Var", "units"]]
+
+class ExampleCompartment(Compartments.Compartment):
+    def __init__(self, name:str, constants = None, source_starting_num = 1000):
+        # Sets lat/long and creates and empty set of compartment labels.
+
+        super().__init__(name, comp_type="Comp", constants=constants)
+        # Crops exist in three stages in this simplified model: planted, growing and harvested.
+        class_labels = [class_entry[0] for class_entry in model_classes]
+        self.addClassLabels(class_labels)
+        
+        self.setInitialConditions({"Source_Var":source_starting_num, "Target_Var":0})
+
+
+def exampleRules():
+    seasonal_production = BasicRules.SingleLocationProductionRule("Comp",
+                                                        "Source_Var", 1,
+                                                        "Target_Var", 1,
+                                                       "model_month_feb", "Source_Var",
+                                                       "Seasonal Source to Target Production")
+    return  seasonal_production
+
+def exampleCompartments():
+    single_comp = ExampleCompartment("Example_Name")
+    return single_comp
+
+model = Model.Model("Basic Epi Model")
+model.buildModel(model_classes, exampleRules, exampleCompartments, write_to_file = True, save_model_folder="Tests/ModelFiles/")
+model_solver = Solvers.GillespieSolver(debug=True)
+model.initializeSolver(model_solver)
+
+start_date = datetime.datetime(2001, 1, 1)
+
+model.simulate(start_date, 365*2, 10000)
+
+print(model.model_state.model_classes)
+
+model.printSimulationPerformanceStats()
+model.trajectory.plotAllClassesOverTime(0)

--- a/Tests/Seasonal_Example.py
+++ b/Tests/Seasonal_Example.py
@@ -6,8 +6,10 @@ import pyRBM.Build.RuleTemplates as BasicRules
 import pyRBM.Simulation.Solvers as Solvers
 
 
-model_classes = [["Source_Var", "units"],
-              ["Target_Var", "units"]]
+model_classes = [["Source_Var_1", "units"],
+              ["Target_Var_1", "units"],
+              ["Source_Var_2", "units"],
+              ["Target_Var_2", "units"]]
 
 class ExampleCompartment(Compartments.Compartment):
     def __init__(self, name:str, constants = None, source_starting_num = 1000):
@@ -18,16 +20,25 @@ class ExampleCompartment(Compartments.Compartment):
         class_labels = [class_entry[0] for class_entry in model_classes]
         self.addClassLabels(class_labels)
         
-        self.setInitialConditions({"Source_Var":source_starting_num, "Target_Var":0})
+        self.setInitialConditions({"Source_Var_1":source_starting_num,
+                                   "Target_Var_1":0,
+                                   "Source_Var_2":source_starting_num,
+                                   "Target_Var_2":0,
+                                   })
 
 
 def exampleRules():
-    seasonal_production = BasicRules.SingleLocationProductionRule("Comp",
-                                                        "Source_Var", 1,
-                                                        "Target_Var", 1,
-                                                       "model_month_feb", "Source_Var",
+    seasonal_production_1 = BasicRules.SingleLocationProductionRule("Comp",
+                                                        "Source_Var_1", 1,
+                                                        "Target_Var_1", 1,
+                                                       "(model_month_feb + model_month_mar + model_month_nov) * Source_Var_1/1000", "Source_Var_1",
                                                        "Seasonal Source to Target Production")
-    return  seasonal_production
+    seasonal_production_2 = BasicRules.SingleLocationProductionRule("Comp",
+                                                    "Source_Var_2", 1,
+                                                    "Target_Var_2", 1,
+                                                    "sin(10*2*pi*model_yearly_day/365) * Source_Var_2/1000", "Source_Var_2",
+                                                    "Seasonal Source to Target Production")
+    return  (seasonal_production_1, seasonal_production_2)
 
 def exampleCompartments():
     single_comp = ExampleCompartment("Example_Name")
@@ -35,11 +46,13 @@ def exampleCompartments():
 
 model = Model.Model("Basic Epi Model")
 model.buildModel(model_classes, exampleRules, exampleCompartments, write_to_file = True, save_model_folder="Tests/ModelFiles/")
-model_solver = Solvers.GillespieSolver(debug=True)
+model_solver = Solvers.HKOSolver(debug=True)
 model.initializeSolver(model_solver)
 
 start_date = datetime.datetime(2001, 1, 1)
 
+model.simulate(start_date, 365*2, 10000)
+model.simulate(start_date, 365*2, 10000)
 model.simulate(start_date, 365*2, 10000)
 
 print(model.model_state.model_classes)

--- a/pyRBM/Build/Classes.py
+++ b/pyRBM/Build/Classes.py
@@ -1,3 +1,5 @@
+from pyRBM.Build.Utils import parseVarName
+
 class Classes:
     def __init__(self, allow_base_model_classes:bool = True):
         self.class_def_dict:dict[str,dict[str,str]] = {}
@@ -9,7 +11,7 @@ class Classes:
     
     def addClass(self, class_name:str, class_measurement_unit:str,
                  class_restriction:str = "None") -> None:
-        class_name = class_name.replace(" ", "_").lower()
+        class_name = parseVarName(class_name)
         if class_name in self.base_model_string:
             raise(ValueError(f"Class: {class_name} cannot contain model prefix{self.base_model_string}"))
         elif not class_name in self.class_names:

--- a/pyRBM/Build/Classes.py
+++ b/pyRBM/Build/Classes.py
@@ -22,6 +22,8 @@ class Classes:
         
     def returnBuiltInClasses(self) -> list[list[str]]:
         builtin_classes = [[f"{self.base_model_string}day",
+                            "Day of month"],
+                            [f"{self.base_model_string}yearly_day",
                             "Day of year"],
                            [f"{self.base_model_string}hour",
                             "Hour of day", "integer"],

--- a/pyRBM/Build/RuleMatching.py
+++ b/pyRBM/Build/RuleMatching.py
@@ -1,6 +1,6 @@
 """ Generic framework to match metarules to compartments, find all compartment indices that match and rewrite the propensities and stoichiometries to use array indices.
 """
-from typing import Any
+from typing import Any, Optional
 
 import numpy as np
 
@@ -134,9 +134,13 @@ def obtainStochiometry(rule:dict[str,Any], compartments:list[dict[str,Any]]) -> 
     return new_stoichiometries
 
 def returnMatchedRulesDict(rules:dict[str,dict[str,Any]], compartments:dict[str,dict[str,Any]],
-                           builtin_classes:list[list[str]]) -> dict[str, dict[str,Any]]:
+                           builtin_classes:Optional[list[list[str]]]) -> dict[str, dict[str,Any]]:
+    if builtin_classes is None:
+        builtin_classes = []
+    else:
+        builtin_classes = sorted(builtin_classes)
+
     matched_rules = returnRuleMatchingIndices(rules, compartments)
-    builtin_classes = sorted(builtin_classes)
     concrete_match_rules_dict = {}
     concrete_rules = 0
     for rule_i in range(len(matched_rules)):

--- a/pyRBM/Build/Utils.py
+++ b/pyRBM/Build/Utils.py
@@ -30,3 +30,7 @@ def createEuclideanDistanceMatrix(lats:Sequence[Union[float, int]],
     # Fill in the lower left triangle
     distm = distm.T+distm
     return distm
+
+
+def parseVarName(class_name:str):
+    return class_name.replace(" ", "_")

--- a/pyRBM/Simulation/Rule.py
+++ b/pyRBM/Simulation/Rule.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional
 
 import numpy as np
 import sympy
@@ -78,16 +79,17 @@ class Rule:
         self.contains_compartment_constant = np.array(self.contains_compartment_constant)
         self.contains_slot_match_constant = np.array(self.contains_slot_match_constant)
 
-    def _subsituteConstants(self, formula_str:str, compartment_constants:dict, compartments_names:list) -> str:
+    def _subsituteConstants(self, formula_str:str, compartment_constants:Optional[dict], compartments_names:list) -> str:
         # The slot to name substitution is performed prior to constant to value substitution,
         # to allow for constant with slot_ to be formed.
         for slots_i, compartment_name in enumerate(compartments_names):
             formula_str = formula_str.replace(f"slot_{slots_i}", compartment_name)
         
         out_formula = formula_str
-        for comp_constant in compartment_constants:
-            out_formula = out_formula.replace(comp_constant,
-                                              str(compartment_constants[comp_constant]))
+        if compartment_constants is not None:
+            for comp_constant in compartment_constants:
+                out_formula = out_formula.replace(comp_constant,
+                                                str(compartment_constants[comp_constant]))
         return out_formula
 
     def _findIndices(self, rule_index_sets:list[list[int]], slot_index:int) -> list[int]:

--- a/pyRBM/Simulation/RuleChain.py
+++ b/pyRBM/Simulation/RuleChain.py
@@ -15,12 +15,13 @@ def _classToRuleDict(rules, compartments, matched_indices, base_classes):
                 comp_classes_num = len(compartments[comp_i].class_values)
                 comp_symbols = rule.sympy_formula[slot_i].atoms(sympy.Symbol)
                 #rtc_dict[f"{rule_i} {index_set_i}"].update([f"{str(symbol)} {comp_i}" for symbol in comp_symbols])
+                
                 for symbol in comp_symbols:
                     class_index = int(str(symbol)[1:])
                     if class_index < comp_classes_num:
-                        ctr_dict[f"{str(symbol)} {comp_i}"].update([f"{rule_i} {index_set_i}"])
+                        ctr_dict[f"{str(symbol)} {comp_i}"].add((rule_i, index_set_i))
                     else:
-                        base_ctr_dict[base_classes[comp_classes_num-class_index]].update([f"{rule_i} {index_set_i}"])
+                        base_ctr_dict[base_classes[class_index-comp_classes_num]].add((rule_i, index_set_i))
     return ctr_dict, base_ctr_dict
 
 # Use propensity infomation to determine which rules require updating based on a change in class value
@@ -43,10 +44,8 @@ def _ruleToRule(rtc_dict, ctr_dict):
 
     for rule_compartment_key in rtr_dict:
         for class_comp in rtc_dict[rule_compartment_key]:
-            rule_index = [index.split(" ")
-                          for index in ctr_dict[class_comp]]
-            rtr_dict[rule_compartment_key].update([(int(index[0]),int(index[1]))
-                                                for index in rule_index])
+            rtr_dict[rule_compartment_key].update(ctr_dict[class_comp])
+    
     return rtr_dict
 
 def returnOneStepRuleUpdates(rules, compartments,

--- a/pyRBM/Simulation/Solvers.py
+++ b/pyRBM/Simulation/Solvers.py
@@ -13,7 +13,17 @@ class Solver:
         self.no_rules_behaviour = no_rules_behaviour
         self.default_step = 1
         self.debug = debug
+    def processNoRuleEvent(self, current_time):
+        if self.no_rules_behaviour == "end":
+            print("Finishing model simulation early.\n No rules left to trigger - all rules have 0 propensity.")
+            return
+        elif self.no_rules_behaviour == "step":
+            print(f"Stepping {self.default_step} ahead.\n No rules left to trigger - all rules have 0 propensity.")
+            if self.debug:
+                self.collectStats(None, None, 0)
 
+            return current_time + self.default_step
+    
     def initialize(self, compartments, rules,
                    matched_indices, model_state:ModelState,
                    propensity_update_dict:Optional[dict] = None) -> None:
@@ -104,15 +114,7 @@ class GillespieSolver(Solver):
         total_propensity = self.returnTotalPropensity()
 
         if total_propensity <= 0:
-            if self.no_rules_behaviour == "end":
-                print("Finishing model simulation early.\n No rules left to trigger - all rules have 0 propensity.")
-                return
-            elif self.no_rules_behaviour == "step":
-                print(f"Stepping {self.default_step} ahead.\n No rules left to trigger - all rules have 0 propensity.")
-                if self.debug:
-                    self.collectStats(None, None, 0)
-
-                return current_time + self.default_step
+            return self.processNoRuleEvent(current_time)
 
         # Generate 0 to 1
         # Random rule
@@ -126,6 +128,11 @@ class GillespieSolver(Solver):
             if cumulative_prop > u1*total_propensity:
                selected_rule_index = rule_comp_key
                break
+        # No rule has been selected as even though total_propensity is non-zero, this is
+        # likely due to numerical precision errors. 
+        if selected_rule_index is None:
+            return self.processNoRuleEvent(current_time)
+        
         # Only set the last rule used when using the caching for propensities.
         if self.use_cached_propensities:
             self.last_rule_index_set = selected_rule_index
@@ -183,12 +190,7 @@ class HKOSolver(Solver):
         total_propensity = self.returnTotalPropensity()
 
         if total_propensity <= 0:
-            if self.no_rules_behaviour == "end":
-                print("Finishing model simulation early.\n No rules left to trigger - all rules have 0 propensity.")
-                return
-            elif self.no_rules_behaviour == "step":
-                print(f"Stepping {self.default_step} ahead.\n No rules left to trigger - all rules have 0 propensity.")
-                return current_time + self.default_step
+            return self.processNoRuleEvent(current_time)
 
         # Generate 0 to 1
         # Random rule
@@ -218,6 +220,10 @@ class HKOSolver(Solver):
                         selected_index_set = int(index_set_key)
                         break
                 break
+        # See dicussion of numerical precision in the Gillespie sovler.
+        if selected_rule is None or selected_index_set is None:
+            return self.processNoRuleEvent(current_time)
+        
         # Only set the last rule used when using the caching for propensities.
         if self.use_cached_propensities:
             self.last_rule_index_set = f"{selected_rule} {selected_index_set}"

--- a/pyRBM/Simulation/Solvers.py
+++ b/pyRBM/Simulation/Solvers.py
@@ -70,11 +70,12 @@ class Solver:
     def performPropensityUpdates(self, update_propensity_func:Callable[[int, int, list], None]) -> None:
         if not self.last_rule_index_set is None:
             rule_prop_update_set = self.propensity_update_dict[self.last_rule_index_set]
-            changed_base_model_vars = self.model_state.returnChangedVars()
-            if not len(changed_base_model_vars) == 0:
+            changed_model_vars = self.model_state.returnChangedVars()
+            if len(changed_model_vars) > 0:
                 rule_prop_update_set = rule_prop_update_set.copy()
-                for changed_model_var in changed_base_model_vars:
-                    rule_prop_update_set.update(self.propensity_update_dict.get(changed_model_var, set()))
+                for changed_var in changed_model_vars:
+                    rule_prop_update_set.update(self.propensity_update_dict[changed_var])
+
             self.updateGivenPropensities(update_propensity_func,
                                          rule_prop_update_set)
         else:

--- a/pyRBM/Simulation/State.py
+++ b/pyRBM/Simulation/State.py
@@ -11,7 +11,7 @@ class ModelState:
         self.model_prefix = "model_"
 
         self.IMPLEMENTED_MODEL_CLASSES = [f"model_{var}"
-                                          for var in ["day", "hour", "months"]]
+                                          for var in ["day", "hour", "months", "yearly_day"]]
         self.IMPLEMENTED_MODEL_CLASSES += [f"model_month_{month}"
                                            for month in self.MONTHS]
         self.model_classes:dict[str,Any] = {}
@@ -73,14 +73,14 @@ class ModelState:
         # https://docs.python.org/3/library/datetime.html#datetime.datetime.timetuple
         current_datetime_info = self.current_datetime.timetuple()
 
-        month_index = current_datetime_info[1]-1
+        month_index = current_datetime_info.tm_mon-1
         # changeModelClassValue checks for a change in value, we incurr a small performance cost in the function call at the benefit of
         # much more maintainable code.
         self.changeMonth(self.current_month, self.MONTHS[month_index], month_index)
-        self.changeModelClassValue("day", current_datetime_info[2])
-
-        rounded_hours = round(current_datetime_info[4]/60.0, 1)
-        self.changeModelClassValue("hour", current_datetime_info[3] + rounded_hours)
+        self.changeModelClassValue("day", current_datetime_info.tm_mday)
+        self.changeModelClassValue("yearly_day", current_datetime_info.tm_yday)
+        rounded_hours = round(current_datetime_info.tm_min/60.0, 1)
+        self.changeModelClassValue("hour", current_datetime_info.tm_hour + rounded_hours)
 
 
     def processUpdate(self, new_time) -> None:

--- a/pyRBM/Simulation/State.py
+++ b/pyRBM/Simulation/State.py
@@ -1,5 +1,5 @@
 # This file is used to allow
-from typing import Iterable
+from typing import Iterable, Any
 from datetime import timedelta, datetime
 
 import numpy as np
@@ -14,7 +14,8 @@ class ModelState:
                                           for var in ["day", "hour", "months"]]
         self.IMPLEMENTED_MODEL_CLASSES += [f"model_month_{month}"
                                            for month in self.MONTHS]
-        self.model_classes = {}
+        self.model_classes:dict[str,Any] = {}
+        self.changed_vars = []
 
         self.time_measurement = "days"
 
@@ -22,75 +23,64 @@ class ModelState:
             if model_class in self.IMPLEMENTED_MODEL_CLASSES:
                 self.model_classes[model_class] = None
             else:
-                self.model_classes[model_class] = None
                 raise ValueError(f"Model class {model_class} not implemented")
-
+            
+        self.resetClassVars()
 
         self.elapsed_time = 0
         self.iterations = 0
         self.current_month = None
-
-        self.changed_vars = [classes for classes in self.model_classes]
-
 
         if isinstance(start_datetime, datetime):
             self.start_datetime = start_datetime
             self.current_datetime = start_datetime
         else:
             raise ValueError(f"Start date must be of type datetime not {type(start_datetime)}")
-        self._initaliseCalendarInfo()
+        self._updateCalendarInfo()
+    
+    def resetClassVars(self):
+        for model_class in self.model_classes:
+            self.changeModelClassValue(model_class[len(self.model_prefix):], 0)
+
 
     def reset(self) -> None:
+        self.changed_vars = []
         self.elapsed_time = 0
         self.iterations = 0
         self.current_datetime = self.start_datetime
-        self.changed_vars = [classes for classes in self.model_classes]
         self._updateCalendarInfo()
-
-    # Convert the self.current_datetime into model variables used
-    def _initaliseCalendarInfo(self) -> None:
-        # Initialise all indicators to zero and perform the standard update step.
-        for key in self.IMPLEMENTED_MODEL_CLASSES:
-            self.model_classes[key] = 0
-        self._updateCalendarInfo()
-
+    
+    def changeModelClassValue(self, class_name:str, new_value:Any):
+        class_name = f"{self.model_prefix}{class_name}"
+        if new_value != self.model_classes[class_name]:
+            self.model_classes[class_name] = new_value
+            self.changed_vars.append(class_name)
+    
+    def changeMonth(self, old_month, new_month, new_month_index):
+        if old_month != new_month:
+            if old_month is not None:
+                self.changeModelClassValue(f"month_{old_month}", 0)
+                self.changeModelClassValue(f"month_{new_month}", 1)
+            self.changeModelClassValue("months", new_month_index)
+            
+            self.current_month = new_month
 
     def changeDate(self, new_date:datetime) -> None:
         self.start_datetime = new_date
         self.reset()
 
     def _updateCalendarInfo(self) -> None:
-
         # https://docs.python.org/3/library/datetime.html#datetime.datetime.timetuple
         current_datetime_info = self.current_datetime.timetuple()
 
         month_index = current_datetime_info[1]-1
-
-        if self.current_month is None:
-            self.model_classes[f"{self.model_prefix}month_{self.MONTHS[month_index]}"] = 1
-            self.model_classes[f"{self.model_prefix}months"] =  current_datetime_info[1]
-            self.current_month = self.MONTHS[month_index]
-
-        if not self.current_month == self.MONTHS[month_index]:
-            self.changed_vars.append(f"{self.model_prefix}month_{self.current_month}")
-            self.changed_vars.append(f"{self.model_prefix}month_{self.MONTHS[month_index]}")
-            self.changed_vars.append(f"{self.model_prefix}months")
-
-            self.model_classes[f"{self.model_prefix}month_{self.current_month}"] = 0
-            self.model_classes[f"{self.model_prefix}month_{self.MONTHS[month_index]}"] = 1
-            self.current_month = self.MONTHS[month_index]
-            self.model_classes[f"{self.model_prefix}months"] =  current_datetime_info[1]
-
-            # Variables that need their propensities updating
-
-        if not self.model_classes[f"{self.model_prefix}day"] == current_datetime_info[2]:
-            self.model_classes[f"{self.model_prefix}day"] = current_datetime_info[2]
-            self.changed_vars.append(f"{self.model_prefix}day")
+        # changeModelClassValue checks for a change in value, we incurr a small performance cost in the function call at the benefit of
+        # much more maintainable code.
+        self.changeMonth(self.current_month, self.MONTHS[month_index], month_index)
+        self.changeModelClassValue("day", current_datetime_info[2])
 
         rounded_hours = round(current_datetime_info[4]/60.0, 1)
-        if not self.model_classes[f"{self.model_prefix}hour"] == current_datetime_info[3] + rounded_hours:
-            self.model_classes[f"{self.model_prefix}hour"] = current_datetime_info[3] + rounded_hours
-            self.changed_vars.append(f"{self.model_prefix}hour")
+        self.changeModelClassValue("hour", current_datetime_info[3] + rounded_hours)
 
 
     def processUpdate(self, new_time) -> None:
@@ -120,7 +110,7 @@ class ModelState:
         return self.model_classes.values()
 
     def returnModelClasses(self):
-        return list(self.model_classes.values())
+        return list(self.model_classes.keys())
 
     def returnChangedVars(self) -> list[str]:
         return self.changed_vars


### PR DESCRIPTION
Added seasonal example to test fixes for model var propensity - sin(days) based example and a monthly indicator example.

Refactored State.py to make code more maintainable.

Fixed model var propensity cache issue caused by line 23 in RuleChain.py and other changes to the RuleChain processes to improve robustness.

Refactored zero total propensity handling into processNoRuleEvent, added check for no rule selection (caused from small difference between total propensity and sum of propensities) and trigger processNoRuleEvent in that case.

Added flexibility to some functions in accepting single objects in addition collections of these objects that were previously accepted.

Fixed errors when no compartment constants are passed.

closes #35 