### PR TITLE
Added exact matching for model and location class names in propensity…

### DIFF
--- a/Tests/SIR_Example.py
+++ b/Tests/SIR_Example.py
@@ -9,21 +9,34 @@ import pyRBM.Simulation.Solvers as Solvers
 epiClasses = [["S", "people"], ["I", "people"], ["R", "people"]]
 
 class EpiCompartment(Compartments.Compartment):
-    def __init__(self, name:str, constants = None):
-        # Sets lat/long and creates and empty set of compartment labels.
+    def __init__(self, name:str, initial_infected, total_population, constants = None):
+        # Provides a list of constants that should be set (optional, but will provide a useful error
+        # message if unset).
         if constants is None:
             constants = ["infectivity_rate", "recovery_rate", "mortality_rate"]
+
         super().__init__(name, comp_type="EpiComp", constants=constants)
         # Crops exist in three stages in this simplified model: planted, growing and harvested.
         class_labels = [class_entry[0] for class_entry in epiClasses]
         self.addClassLabels(class_labels)
+
+        self.setInitialConditions({"S":total_population-initial_infected,
+                                   "I":initial_infected})
+        
+
+def epiLocations():
+    single_epi_comp = EpiCompartment("Example_SIR_Model", initial_infected=5, total_population=100,
+                                     constants={"infectivity_rate" : 0.4,
+                                                "recovery_rate" : 0.1,
+                                                "mortality_rate" : 0.3 })
+    return single_epi_comp
 
 
 def epiRules():
     infection = BasicRules.SingleLocationProductionRule("EpiComp",
                                                         "S", 1,
                                                         "I", 1,
-                                                       "S*I*comp_infectivity_rate", ["I","S"],
+                                                       "S*(I/(S+I+R))*comp_infectivity_rate", ["S", "I","R"],
                                                        "Infection of Susceptible")
     recovery = BasicRules.SingleLocationProductionRule("EpiComp",
                                                        "I", 1,
@@ -31,16 +44,14 @@ def epiRules():
                                                        "I*comp_recovery_rate", "I", 
                                                        "Recovery of Infected")
     death = BasicRules.ExitEntranceRule("EpiComp",
-                                        "I", 1,
+                                        "I", -1,
                                         "I*comp_mortality_rate", "I",
                                         "Death of Infected")
-    return  [infection, recovery, death]
+    return  (infection, recovery, death)
 
-def epiLocations():
-    single_epi_comp = EpiCompartment("Example_Name", constants={"infectivity_rate" : 0.1,
-                                                                "recovery_rate" : 0.2,
-                                                                "mortality_rate" : 0.3 })
-    return [single_epi_comp]
+
+
+
 
 model = Model.Model("Basic Epi Model")
 model.buildModel(epiClasses, epiRules, epiLocations, write_to_file = True, save_model_folder="Tests/ModelFiles/")
@@ -49,7 +60,8 @@ model.initializeSolver(model_solver)
 
 start_date = datetime.datetime(2001, 8, 1)
 
-model.simulate(start_date, 10000, 10000)
+
+model.simulate(start_date, 40, 100000)
 
 
 model.printSimulationPerformanceStats()

--- a/pyRBM/Simulation/Rule.py
+++ b/pyRBM/Simulation/Rule.py
@@ -79,11 +79,12 @@ class Rule:
         self.contains_compartment_constant = np.array(self.contains_compartment_constant)
         self.contains_slot_match_constant = np.array(self.contains_slot_match_constant)
 
-    def _subsituteConstants(self, formula_str:str, compartment_constants:Optional[dict], compartments_names:list) -> str:
+    def _subsituteConstants(self, formula_str:str, compartment_constants:Optional[dict], compartments_names:Optional[list]) -> str:
         # The slot to name substitution is performed prior to constant to value substitution,
         # to allow for constant with slot_ to be formed.
-        for slots_i, compartment_name in enumerate(compartments_names):
-            formula_str = formula_str.replace(f"slot_{slots_i}", compartment_name)
+        if compartments_names is not None:
+            for slots_i, compartment_name in enumerate(compartments_names):
+                formula_str = formula_str.replace(f"slot_{slots_i}", compartment_name)
         
         out_formula = formula_str
         if compartment_constants is not None:


### PR DESCRIPTION
- Improved SIR example and fixed an issue with constants replacement found in the SIR example case.

- Uses re.sub to match the class name and model constants exactly (i.e. no pre/post fixing).

closes #33 